### PR TITLE
Add demo for educational purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,31 @@ function sk() {
 Replacing `/path/to/surfkit/repo` with the absolute path to your local repo.
 
 Then calling `sk` will execute the working code in your repo from any location.
+
+## Demonstrating the `surfkit` CLI for Educational Purposes
+
+This section demonstrates how to use the `surfkit` CLI to create and manage agents and tasks, which can be used in educational presentations.
+
+### Creating an Agent
+
+To create an agent using the `surfkit` CLI, use the following command:
+
+```sh
+surfkit create agent --name my_agent --type pbarker/SurfPizza
+```
+
+### Listing Agents
+
+To list all the agents, use the following command:
+
+```sh
+surfkit list agents
+```
+
+### Following Agent Logs
+
+To follow the logs of an agent, use the following command:
+
+```sh
+surfkit logs agent my_agent --follow
+```

--- a/surfkit/cli/main.py
+++ b/surfkit/cli/main.py
@@ -26,6 +26,7 @@ view_group = typer.Typer(help="View resources")
 delete_group = typer.Typer(help="Delete resources")
 logs_group = typer.Typer(help="Resource logs")
 clean_group = typer.Typer(help="Clean resources")
+demo_group = typer.Typer(help="Demonstrate CLI usage")
 
 app.add_typer(create_group, name="create")
 app.add_typer(list_group, name="list")
@@ -33,6 +34,7 @@ app.add_typer(get_group, name="get")
 app.add_typer(view_group, name="view")
 app.add_typer(delete_group, name="delete")
 app.add_typer(logs_group, name="logs")
+app.add_typer(demo_group, name="demo")
 # app.add_typer(clean_group, name="clean")
 
 
@@ -1711,5 +1713,38 @@ def config():
         typer.echo(f"API key: {config.api_key}")
 
 
-if __name__ == "__main__":
-    app()
+@demo_group.command("create-agent")
+def demo_create_agent():
+    """
+    Demonstrate creating an agent using the surfkit CLI.
+    """
+    typer.echo("Creating an agent using the surfkit CLI...")
+    create_agent(
+        runtime="docker",
+        type="pbarker/SurfPizza",
+        name="demo_agent",
+        auth_enabled=False,
+        local_keys=False,
+        debug=False,
+    )
+    typer.echo("Agent 'demo_agent' created successfully.")
+
+
+@demo_group.command("list-agents")
+def demo_list_agents():
+    """
+    Demonstrate listing agents using the surfkit CLI.
+    """
+    typer.echo("Listing agents using the surfkit CLI...")
+    list_agents(runtime="docker")
+    typer.echo("Agents listed successfully.")
+
+
+@demo_group.command("follow-logs")
+def demo_follow_logs():
+    """
+    Demonstrate following agent logs using the surfkit CLI.
+    """
+    typer.echo("Following logs of agent 'demo_agent' using the surfkit CLI...")
+    get_agent_logs(name="demo_agent", runtime="docker", follow=True)
+    typer.echo("Logs followed successfully.")


### PR DESCRIPTION
Add demonstration of `surfkit` CLI usage for educational purposes.

* **README.md**
  - Add a section demonstrating how to use the `surfkit` CLI to create and manage agents and tasks.
  - Include examples of creating an agent, listing agents, and following logs.

* **surfkit/cli/main.py**
  - Add a new `demo` command group to demonstrate CLI usage.
  - Add commands to demonstrate creating an agent, listing agents, and following logs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bossm747/innovatehub-surfkit/pull/1?shareId=dc09dc32-8515-4145-ad20-d3c486a0ab7c).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a demonstration section to the README for educational purposes and introduce a new command group 'demo' in the `surfkit` CLI for demonstrating functionalities such as creating agents, listing agents, and following agent logs.

### Why are these changes being made?

These changes enhance the educational utility of the `surfkit` by providing clear examples in the documentation and CLI, making it easier for new users to understand and utilize the tool effectively. These additions serve as practical guides and facilitate onboarding and presentations, addressing a need for clearer user education and demonstration practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->